### PR TITLE
More checks before setting up nsc-remote

### DIFF
--- a/common.ts
+++ b/common.ts
@@ -1,3 +1,4 @@
 export const nscRemoteBuilderName = "nsc-remote";
+export const nscInRunnerBuilderName = "in-runner-builder"
 export const nscDebugFolder = "/home/runner/nsc";
 export const nscVmIdKey = 'NSC_VM_ID';


### PR DESCRIPTION
Use `nsc docker buildx status` first to check for presence.
This does not generate traffic.

Don't set up nsc-remote if in-runner-builder is present.
The assumption is that a runner profile selected builder is already
present in this case so this action should not override it.
